### PR TITLE
Fix image path in 404 page

### DIFF
--- a/FeuerMoodle/resources/views/errors/404.blade.php
+++ b/FeuerMoodle/resources/views/errors/404.blade.php
@@ -10,13 +10,13 @@
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
         
         <!--CUSTOM CSS -->
-        <link href="css/404.css" rel="stylesheet">
+        <link href="{{ url('css/404.css') }}" rel="stylesheet">
     </head>
     <body class="bg-dark text-white">
         <div class="text-center container min-vh-100">
             <div class="d-flex flex-column justify-content-center align-items-center min-vh-100">
                 <div class="col-12 col-md-8 col-lg-6 col-xl-5">
-                    <img src="images/404-broken-pencil.svg" width="400" height="200">
+                    <img src="{{ url('images/404-broken-pencil.svg') }}" width="400" height="200">
                     <div>
                         <h1>4<span class="logo"></span>4</h1>
                     </div>


### PR DESCRIPTION
Fixed svg image resource path and css to laravel url helper function, so the images appear correctly if you get a 404 error and it works with any url path